### PR TITLE
Add LongestPalindromicSubstring class with IDisposable

### DIFF
--- a/leetcode/leetcode/LongestPalindromicSubstring.cs
+++ b/leetcode/leetcode/LongestPalindromicSubstring.cs
@@ -1,0 +1,78 @@
+﻿
+
+namespace leetcode
+{
+    public class LongestPalindromicSubstring : IDisposable
+    {
+        private bool disposedValue;
+
+        public  string LongestPalindrome(string s)
+        {
+            if (string.IsNullOrEmpty(s) || s.Length < 1)
+                return "";
+   
+            int start = 0, end = 0;
+            
+            for (int i = 0; i < s.Length; i++)
+            {
+                // Odd length palindrome
+                int len1 = ExpandFromCenter(s, i, i);
+                // Even length palindrome
+                int len2 = ExpandFromCenter(s, i, i + 1);
+
+                int len = Math.Max(len1, len2);
+
+                if (len > end - start)
+                {
+                    start = i - (len - 1) / 2;
+                    end = i + len / 2;
+                }
+            }
+
+            return s.Substring(start, end - start + 1);
+        }
+
+        private  int ExpandFromCenter(string s, int left, int right)
+        {
+            while (left >= 0 && right < s.Length && s[left] == s[right])
+            {
+                left--;
+                right++;
+            }
+            return right - left - 1;
+        }
+
+
+
+
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects)
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        // ~LongestPalindromicSubstring()
+        // {
+        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        //     Dispose(disposing: false);
+        // }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/leetcode/leetcode/Program.cs
+++ b/leetcode/leetcode/Program.cs
@@ -98,3 +98,7 @@ Console.WriteLine(birthdayCake.birthdayCakeCandles(candles));
 LongestSubstring longestSubstring=new LongestSubstring();
 Console.WriteLine(longestSubstring.LengthOfLongestSubstring("abcabcbb"));
 longestSubstring.Dispose();
+LongestPalindromicSubstring palindromicSubstring=new LongestPalindromicSubstring();
+Console.WriteLine(palindromicSubstring.LongestPalindrome("babad"));
+Console.WriteLine(palindromicSubstring.LongestPalindrome("cbbd"));
+palindromicSubstring.Dispose();


### PR DESCRIPTION
Add LongestPalindromicSubstring class with IDisposable

Introduces the `LongestPalindromicSubstring` class in the `leetcode` namespace, featuring a method to find the longest palindromic substring using center expansion. Implements the `IDisposable` interface for resource management. Updates `Program.cs` to demonstrate the functionality of the new class.

#### PR Classification
New feature to implement a class for finding the longest palindromic substring.

#### PR Summary
This pull request introduces the `LongestPalindromicSubstring` class, which provides functionality to find the longest palindromic substring in a given string. It also demonstrates its usage in the `Program.cs` file.
- `LongestPalindromicSubstring.cs`: Added the `LongestPalindromicSubstring` class with methods `LongestPalindrome` and `ExpandFromCenter`, and implemented `IDisposable`.
- `Program.cs`: Created instances of `LongestPalindromicSubstring` and called `LongestPalindrome` with example strings, printing the results to the console.
